### PR TITLE
update timm version to support repvit models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 torch
-timm==0.5.4 
+timm==0.9.12
 fvcore


### PR DESCRIPTION
update timm version to support repvit models, the one in original repo, the timm version in requirements.txt file gives error when trying to run `create_model('repvit_m0_9')` function